### PR TITLE
Use From-field to set name of sender in outgoing mails

### DIFF
--- a/android/src/main/java/com/reactlibrary/RNSmtpMailerModule.java
+++ b/android/src/main/java/com/reactlibrary/RNSmtpMailerModule.java
@@ -71,7 +71,7 @@ public class RNSmtpMailerModule extends ReactContextBaseJavaModule {
             public void run() {
                 try {
                     MailSender sender = new MailSender(username, password, mailhost, port, ssl);
-                    sender.sendMail(subject, body, from, recipients, bcc, attachmentPaths, attachmentNames, attachmentTypes);
+                    sender.sendMail(subject, body, username, from, recipients, bcc, attachmentPaths, attachmentNames, attachmentTypes);
 
                     WritableMap success = new WritableNativeMap();
                     success.putString("status", "SUCCESS");
@@ -124,13 +124,18 @@ class MailSender extends javax.mail.Authenticator {
         return new PasswordAuthentication(user, password);
     }
 
-    public synchronized void sendMail(String subject, String body, String sender, String recipients, ReadableArray bcc,
+    public synchronized void sendMail(String subject, String body, String sender, String senderAlias, String recipients, ReadableArray bcc,
           ReadableArray attachmentPaths, ReadableArray attachmentNames, ReadableArray attachmentTypes) throws Exception {
         MimeMessage message = new MimeMessage(session);
         Transport transport = session.getTransport();
         BodyPart messageBodyPart = new MimeBodyPart();
 
-        message.setFrom(new InternetAddress(sender, ""));
+        // Try to set custom 'from' alias
+        if(senderAlias != null && !senderAlias.isEmpty())
+            message.setFrom(new InternetAddress(sender, senderAlias));
+        else
+            message.setFrom(new InternetAddress(sender, ""));
+
         message.setSubject(subject);
         message.setSentDate(new Date());
 

--- a/ios/RNSmtpMailer.m
+++ b/ios/RNSmtpMailer.m
@@ -35,8 +35,8 @@ RCT_EXPORT_METHOD(sendMail:(NSDictionary *)obj resolver:(RCTPromiseResolveBlock)
     smtpSession.authType = MCOAuthTypeSASLPlain;
     smtpSession.connectionType = MCOConnectionTypeTLS;
     MCOMessageBuilder *builder = [[MCOMessageBuilder alloc] init];
-    MCOAddress *from = [MCOAddress addressWithDisplayName:nil
-                                                mailbox:fromEmail];
+    MCOAddress *from = [MCOAddress addressWithDisplayName:fromEmail
+                                                mailbox:username];
     MCOAddress *to = [MCOAddress addressWithDisplayName:nil
                                               mailbox:recipients];
 


### PR DESCRIPTION
As brought up by @justin-dai in https://github.com/angelos3lex/react-native-smtp-mailer/issues/7#issuecomment-495385303, there is currently not a way to set a custom name of sender. From what I can tell as of the current code, `from` is not actually used for anything? Maybe it is and I fail to see that case? :)

I also would like to see this as being optional (as BCC list is, see #17), as it is not strictly necessary to set a custom alias in order to send an email.

Either way, it would be nice to able to set a custom alias. So far, this is only a draft and any inputs would be appreciated!

#### TODO

- [X] Implement draft for setting sender alias on Android
- [ ] Make sender alias optional on Android
- [x] Implement draft for setting sender alias on iOS
- [ ] Make sender alias optional on iOS